### PR TITLE
Crude Debug Web UI setup

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/yaml"
+	"net/http"
+)
+
+func NewConfigHandler(config *koanf.Koanf) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		data, err := config.Marshal(yaml.Parser())
+		if err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			_, _ = writer.Write([]byte(err.Error()))
+			return
+		}
+
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(data)
+	}
+}

--- a/api/debug/handler.go
+++ b/api/debug/handler.go
@@ -1,0 +1,65 @@
+package debug
+
+import (
+	"bytes"
+	"dolittle.io/kokk/api/utils"
+	"encoding/json"
+	"net/http"
+	"sort"
+)
+
+func NewDebugHandler(output Repository) (http.Handler, error) {
+	handler := http.NewServeMux()
+
+	list, err := utils.NewTemplateHandler("api/debug/list.html", func(r *http.Request) (any, error) {
+		resources := output.List()
+		ids := make([]string, 0, len(resources))
+		for _, resource := range resources {
+			ids = append(ids, resource.Id)
+		}
+		sort.Strings(ids)
+
+		return listData{
+			IDs: ids,
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	view, err := utils.NewTemplateHandler("api/debug/view.html", func(r *http.Request) (any, error) {
+		resourceID := r.URL.Path
+		resource, err := output.Get(resourceID)
+		if err != nil {
+			return nil, err
+		}
+
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, resource.Content, "", "  "); err != nil {
+			return nil, err
+		}
+
+		return viewData{
+			ID:      resource.Id,
+			Content: pretty.String(),
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	handler.Handle("/debug/list", list)
+	handler.Handle("/debug/view/", http.StripPrefix("/debug/view/", view))
+	handler.Handle("/debug/", http.RedirectHandler("/debug/list", http.StatusTemporaryRedirect))
+
+	return handler, nil
+}
+
+type listData struct {
+	IDs []string
+}
+
+type viewData struct {
+	ID      string
+	Content string
+}

--- a/api/debug/list.html
+++ b/api/debug/list.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Debug List</title>
+    </head>
+    <body>
+        <h1>All monitored resources:</h1>
+        <ol>
+            {{range .IDs}}
+                <li><a href="/debug/view/{{ .  }}">{{ . }}</a></li>
+            {{end}}
+        </ol>
+    </body>
+</html>

--- a/api/debug/resources.go
+++ b/api/debug/resources.go
@@ -1,0 +1,8 @@
+package debug
+
+import "dolittle.io/kokk/resources"
+
+type Repository interface {
+	List() []resources.Resource
+	Get(id string) (*resources.Resource, error)
+}

--- a/api/debug/view.html
+++ b/api/debug/view.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Debug View</title>
+    </head>
+    <body>
+        <h1>{{ .ID }}</h1>
+        <pre>{{ .Content }}</pre>
+    </body>
+</html>

--- a/api/index.html
+++ b/api/index.html
@@ -7,6 +7,7 @@
         <h1>Endpoints:</h1>
         <ul>
             <li><a href="/debug/">Debug internal status</a></li>
+            <li><a href="/config">View configuration in use</a></li>
         </ul>
     </body>
 </html>

--- a/api/index.html
+++ b/api/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Service UI</title>
+    </head>
+    <body>
+        <h1>Hello world.</h1>
+    </body>
+</html>

--- a/api/index.html
+++ b/api/index.html
@@ -4,6 +4,9 @@
         <title>Service UI</title>
     </head>
     <body>
-        <h1>Hello world.</h1>
+        <h1>Endpoints:</h1>
+        <ul>
+            <li><a href="/debug/">Debug internal status</a></li>
+        </ul>
     </body>
 </html>

--- a/api/server.go
+++ b/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"dolittle.io/kokk/api/debug"
 	"dolittle.io/kokk/api/utils"
 	"fmt"
 	"github.com/google/uuid"
@@ -11,7 +12,7 @@ import (
 	"time"
 )
 
-func NewServer(config *koanf.Koanf, logger *zerolog.Logger) (*http.Server, error) {
+func NewServer(config *koanf.Koanf, output debug.Repository, logger *zerolog.Logger) (*http.Server, error) {
 	handler := apiHandler{
 		router: http.NewServeMux(),
 		logger: logger,
@@ -28,7 +29,13 @@ func NewServer(config *koanf.Koanf, logger *zerolog.Logger) (*http.Server, error
 		return nil, err
 	}
 
+	ui, err := debug.NewDebugHandler(output)
+	if err != nil {
+		return nil, err
+	}
+
 	handler.router.Handle("/", index)
+	handler.router.Handle("/debug/", ui)
 
 	logger.Info().Int("port", handler.config.Port).Msg("API Server configured")
 

--- a/api/server.go
+++ b/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"dolittle.io/kokk/api/utils"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/knadh/koanf"
@@ -19,6 +20,15 @@ func NewServer(config *koanf.Koanf, logger *zerolog.Logger) (*http.Server, error
 	if err := config.Unmarshal("server", &handler.config); err != nil {
 		return nil, err
 	}
+
+	index, err := utils.NewTemplateHandler("api/index.html", func(r *http.Request) (any, error) {
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	handler.router.Handle("/", index)
 
 	logger.Info().Int("port", handler.config.Port).Msg("API Server configured")
 

--- a/api/server.go
+++ b/api/server.go
@@ -29,12 +29,15 @@ func NewServer(config *koanf.Koanf, output debug.Repository, logger *zerolog.Log
 		return nil, err
 	}
 
+	conf := NewConfigHandler(config)
+
 	ui, err := debug.NewDebugHandler(output)
 	if err != nil {
 		return nil, err
 	}
 
 	handler.router.Handle("/", index)
+	handler.router.Handle("/config", conf)
 	handler.router.Handle("/debug/", ui)
 
 	logger.Info().Int("port", handler.config.Port).Msg("API Server configured")

--- a/api/server.go
+++ b/api/server.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/knadh/koanf"
+	"github.com/rs/zerolog"
+	"net/http"
+	"time"
+)
+
+func NewServer(config *koanf.Koanf, logger *zerolog.Logger) (*http.Server, error) {
+	handler := apiHandler{
+		router: http.NewServeMux(),
+		logger: logger,
+	}
+
+	if err := config.Unmarshal("server", &handler.config); err != nil {
+		return nil, err
+	}
+
+	logger.Info().Int("port", handler.config.Port).Msg("API Server configured")
+
+	return &http.Server{
+		Addr:    fmt.Sprintf(":%d", handler.config.Port),
+		Handler: &handler,
+	}, nil
+}
+
+type apiHandler struct {
+	config apiHandlerConfig
+	router *http.ServeMux
+	logger *zerolog.Logger
+}
+
+type apiHandlerConfig struct {
+	Port int `koanf:"port"`
+}
+
+func (a *apiHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	requestID := uuid.NewString()
+	start := time.Now()
+
+	a.logger.Info().Str("request_id", requestID).Str("method", request.Method).Str("path", request.URL.Path).Msg("Started handling request")
+
+	idContext := context.WithValue(request.Context(), "request_id", requestID)
+	requestWithIdContext := request.WithContext(idContext)
+	a.router.ServeHTTP(writer, requestWithIdContext)
+
+	elapsed := time.Since(start)
+	a.logger.Info().Str("request_id", requestID).Float64("duration", elapsed.Seconds()).Msg("Finished handling request")
+}

--- a/api/utils/template.go
+++ b/api/utils/template.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"html/template"
+	"net/http"
+)
+
+type TemplateHandler struct {
+	template *template.Template
+	handler  func(r *http.Request) (any, error)
+}
+
+func NewTemplateHandler(path string, handler func(r *http.Request) (any, error)) (http.Handler, error) {
+	parsed, err := template.ParseFiles(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TemplateHandler{
+		template: parsed,
+		handler:  handler,
+	}, nil
+}
+
+func (t *TemplateHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	data, err := t.handler(request)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, _ = writer.Write([]byte(err.Error()))
+		return
+	}
+
+	writer.WriteHeader(http.StatusOK)
+	_ = t.template.Execute(writer, data)
+}

--- a/cmd/serve/cmd.go
+++ b/cmd/serve/cmd.go
@@ -32,7 +32,7 @@ var Command = &cobra.Command{
 
 		output.List()
 
-		server, err := api.NewServer(config, logger)
+		server, err := api.NewServer(config, output, logger)
 		if err != nil {
 			return err
 		}

--- a/cmd/serve/cmd.go
+++ b/cmd/serve/cmd.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"dolittle.io/kokk/api"
 	"dolittle.io/kokk/config"
 	"dolittle.io/kokk/kubernetes"
 	"dolittle.io/kokk/output"
@@ -31,11 +32,17 @@ var Command = &cobra.Command{
 
 		output.List()
 
-		return err
+		server, err := api.NewServer(config, logger)
+		if err != nil {
+			return err
+		}
+
+		return server.ListenAndServe()
 	},
 }
 
 func init() {
+	Command.Flags().Int("server.port", 8080, "The port to listen to")
 	Command.Flags().StringSlice("kubernetes.resources", []string{"Namespace", "Deployment"}, "The Kubernetes resource types to operate on")
 	Command.Flags().Int("kubernetes.resync", 60, "The Kubernetes informer resync interval")
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,6 @@
 logger:
   format: console
   level: debug
+
+server:
+  port: 8080

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module dolittle.io/kokk
 go 1.18
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/knadh/koanf v1.4.2
 	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,9 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=


### PR DESCRIPTION
A quick version of a HTML UI that we can use for viewing internal status and debugging. Currently it as one page that prints out the current config in YAML format, and two pages for debugging 1) that lists all the current resources monitored from Kubernetes, and 2) if you click one of the links, you see the pretty printed JSON contents of that resource.